### PR TITLE
Add support for "query" loader config

### DIFF
--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -150,14 +150,19 @@ HappyPlugin.prototype.start = function(compiler, done) {
         })[0];
 
         if (sourceLoaderConfig) {
-          loaders = sourceLoaderConfig.loaders || [ sourceLoaderConfig.loader ];
+          loaders = WebpackUtils.extractLoaders(sourceLoaderConfig);
 
           // yeah, yuck... we need to overwrite, ugly!
           sourceLoaderConfig.loader = path.resolve(__dirname, 'HappyLoader.js') + '?id=' + that.id;
+          delete sourceLoaderConfig.query;
+          delete sourceLoaderConfig.loaders;
+
+          // TODO: it would be nice if we can restore those mutations at some
+          // point
         }
       }
 
-      assert(loaders,
+      assert(loaders && loaders.length > 0,
         "HappyPlugin[" + that.id + "]; you have not specified any loaders " +
         "and there is no matching loader entry with this id either."
       );

--- a/lib/WebpackUtils.js
+++ b/lib/WebpackUtils.js
@@ -15,6 +15,72 @@ exports.disectLoaderString = function disectLoaderString(string) {
   }
 };
 
+/**
+ * Extract the set of loaders (one or more) from a given a "module.loaders"
+ * webpack config entry.
+ *
+ * Example inputs/outputs:
+ *
+ *     // a loader chain
+ *     {
+ *       loaders: [ 'style', 'css' ]
+ *     }
+ *     // => [ "style", "css" ]
+ *
+ *     // another loader chain
+ *     {
+ *       loaders: [ 'style!css' ]
+ *     }
+ *     // => [ "style!css" ]
+ *
+ *     // a single loader, no query:
+ *     {
+ *       loader: 'babel'
+ *     }
+ *     // => [ "babel" ]
+ *
+ *     // a single loader with inline query:
+ *     {
+ *       loader: 'babel?presets[]=react'
+ *     }
+ *     // => [ "babel?presets[]=react" ]
+ *
+ *     // a single loader with a query object:
+ *     {
+ *       loader: 'babel',
+ *       query: { presets: [ 'react' ] }
+ *     }
+ *     // => [ "babel?presets[]=react" ]
+ *
+ * @param  {Object} entry
+ * @param  {Array.<String>?} entry.loaders
+ * @param  {String?} entry.loader
+ * @param  {Object?} entry.query
+ *
+ * @return {Array.<String>}
+ */
+exports.extractLoaders = function extractLoaders(entry) {
+  if (entry.loaders) {
+    return entry.loaders;
+  }
+
+  var query = '';
+
+  if (entry.query) {
+    if (typeof entry.query === 'object') {
+      query = '?' + JSON.stringify(entry.query);
+    }
+    else if (typeof entry.query === 'string') {
+      query = entry.query[0] === '?' ? '' : '?';
+      query += entry.query;
+    }
+  }
+
+  return [
+    entry.loader + query
+  ];
+};
+
 exports.resolveLoaders = function(compiler, loaders, done) {
   async.parallel(loaders.map(function(loader) {
     assert(!!loader, "Invalid loader string to resolve!!! " + JSON.stringify(loaders));

--- a/lib/__tests__/HappyPlugin.integration.test.js
+++ b/lib/__tests__/HappyPlugin.integration.test.js
@@ -178,6 +178,59 @@ describe('[Integration] HappyPlugin', function() {
     });
   });
 
+  it("passes query object to the loader", function(done) {
+    const outputDir = tempDir('integration-[guid]');
+    const loader = createLoader(function(s) {
+      return s + `\n// ${this.query}`
+    });
+
+    const compiler = webpack({
+      entry: {
+        main: [
+          fixturePath('integration/index.js')
+        ]
+      },
+
+      output: {
+        filename: '[name].js',
+        path: outputDir
+      },
+
+      module: {
+        loaders: [{
+          test: /.js$/,
+          happy: { id: 'js' },
+          loader: loader._name,
+          query: {
+            string: 'HAPPY'
+          }
+        }]
+      },
+
+      resolveLoader: {
+        root: path.dirname(loader.path)
+      },
+
+      plugins: [
+        new HappyPlugin({ id: 'js' })
+      ]
+    });
+
+    compiler.run(function(err, rawStats) {
+      if (err) { return done(err); }
+
+      const stats = rawStats.toJson();
+
+      if (stats.errors.length > 0) {
+        return done(stats.errors);
+      }
+
+      assert.match(fs.readFileSync(path.join(outputDir, 'main.js'), 'utf-8'), '// ?{"string":"HAPPY"}');
+
+      done();
+    });
+  });
+
   it("passes compiler options down to the background loaders", function(done) {
     const outputDir = tempDir('integration-[guid]');
     const loader = createLoader(function() {


### PR DESCRIPTION
Webpack supports defining query options for a loader as an object when
using the single-loader notation (module.loaders[].loader) which gets
JSON.stringified implicitly and passed down to the loader as a "query
string".

When HappyPack is expected to infer the loaders from webpack's config,
it has to take that query out and pass it down to the real loaders.
Prior to this patch, the query was left untouched and instead was being
passed to the *happy* loader (by webpack), which then gets confused by
those extraneous query params, preventing it from finding its plugin
instance.

Closes #26